### PR TITLE
Fix overlap bug order

### DIFF
--- a/src/cidr/core.cljc
+++ b/src/cidr/core.cljc
@@ -96,5 +96,5 @@
   [cidr-str-a cidr-str-b]
   (let [[min-a max-a] (apply cidr->ips (str->cidr cidr-str-a))
         [min-b max-b] (apply cidr->ips (str->cidr cidr-str-b))]
-    (or (>= min-a min-b)
-        (<= max-b max-a))))
+    (or (>= min-a min-b max-a)
+        (<= max-b max-a min-b))))

--- a/src/cidr/core.cljc
+++ b/src/cidr/core.cljc
@@ -96,5 +96,5 @@
   [cidr-str-a cidr-str-b]
   (let [[min-a max-a] (apply cidr->ips (str->cidr cidr-str-a))
         [min-b max-b] (apply cidr->ips (str->cidr cidr-str-b))]
-    (or (>= min-a min-b max-a)
-        (<= max-b max-a min-b))))
+    (or (and (>= min-a min-b) (>= min-b max-a))
+        (and (<= max-b max-a) (>= max-b min-a)))))

--- a/src/cidr/core.cljc
+++ b/src/cidr/core.cljc
@@ -96,5 +96,7 @@
   [cidr-str-a cidr-str-b]
   (let [[min-a max-a] (apply cidr->ips (str->cidr cidr-str-a))
         [min-b max-b] (apply cidr->ips (str->cidr cidr-str-b))]
-    (or (and (>= min-a min-b) (>= min-b max-a))
-        (and (<= max-b max-a) (>= max-b min-a)))))
+    (or (<= min-a min-b max-a)
+        (<= min-b max-a max-b)
+        (<= min-a max-b max-a)
+        (<= min-b min-a max-b))))

--- a/test/cidr/core_test.clj
+++ b/test/cidr/core_test.clj
@@ -33,7 +33,8 @@
 
 (deftest overlap?-test
   (testing "that working out whether two ranges overlap returns false when they don't overlap at all"
-    (is (not (overlap? "9.0.0.0/8" "10.0.0.0/8"))))
+    (is (not (overlap? "9.0.0.0/8" "10.0.0.0/8")))
+    (is (not (overlap? "10.0.0.0/8" "9.0.0.0/8"))))
 
   (testing "that working out whether two ranges overlap returns false when they don't overlap at all"
     (is (overlap? "10.0.0.255/30" "10.0.0.255/32")))

--- a/test/cidr/core_test.clj
+++ b/test/cidr/core_test.clj
@@ -37,7 +37,9 @@
     (is (not (overlap? "10.0.0.0/8" "9.0.0.0/8"))))
 
   (testing "that working out whether two ranges overlap returns false when they don't overlap at all"
-    (is (overlap? "10.0.0.255/30" "10.0.0.255/32")))
+    (is (overlap? "10.0.0.255/30" "10.0.0.255/32"))
+    (is (overlap? "10.0.0.255/21" "10.0.0.255/21"))
+    (is (overlap? "10.140.48.0/20" "10.140.48.0/20")))
 
   (testing "that working out whether two ranges overlap returns false when they don't overlap at all"
     (is (overlap? "10.0.0.2/30" "10.0.0.3/32"))))

--- a/test/cidr/core_test.clj
+++ b/test/cidr/core_test.clj
@@ -39,7 +39,9 @@
   (testing "that working out whether two ranges overlap returns false when they don't overlap at all"
     (is (overlap? "10.0.0.255/30" "10.0.0.255/32"))
     (is (overlap? "10.0.0.255/21" "10.0.0.255/21"))
-    (is (overlap? "10.140.48.0/20" "10.140.48.0/20")))
+    (is (overlap? "10.140.48.0/20" "10.140.48.0/20"))
+    (is (overlap? "10.1.0.0/20" "10.1.0.0/21"))
+    (is (overlap? "10.1.0.0/21" "10.1.0.0/20")))
 
   (testing "that working out whether two ranges overlap returns false when they don't overlap at all"
     (is (overlap? "10.0.0.2/30" "10.0.0.3/32"))))


### PR DESCRIPTION
I found an issue related to the order of the parameters. 
```
FAIL in (overlap?-test) (core_test.clj:37)
that working out whether two ranges overlap returns false when they don't overlap at all
expected: (not (overlap? "10.0.0.0/8" "9.0.0.0/8"))
  actual: (not (not true))
```

I hope that helps others.

Thanks for this simple lib, 
Marko Souza